### PR TITLE
CORS Allow All

### DIFF
--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -34,6 +34,8 @@ func (h *GraphQL) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST OPTIONS")
 	if _, err := w.Write(responseJSON); err != nil {
 		log.Println(err)
 	}


### PR DESCRIPTION
## Summary

Add the following headers to responses to make sure CORS allows all hosts:
* `Access-Control-Allow-Origin`: `*`
* `Access-Control-Allow-Methods`: `POST OPTIONS`