### PR TITLE
Handle Empty-bodied Requests

### DIFF
--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -1,7 +1,9 @@
 package handler
 
 import (
+	"bytes"
 	"encoding/json"
+	"io/ioutil"
 	"log"
 	"net/http"
 
@@ -20,22 +22,37 @@ func (h *GraphQL) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		OperationName string                 `json:"operationName"`
 		Variables     map[string]interface{} `json:"variables"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	ctx := h.Loaders.Attach(r.Context())
+	var responseJSON []byte
 
-	response := h.Schema.Exec(ctx, params.Query, params.OperationName, params.Variables)
-	responseJSON, err := json.Marshal(response)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
+	// set all response params here
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "POST OPTIONS")
+
+	// check for empty body
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+
+	if len(body) > 0 {
+		if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		ctx := h.Loaders.Attach(r.Context())
+
+		response := h.Schema.Exec(ctx, params.Query, params.OperationName, params.Variables)
+		responseJSON, err = json.Marshal(response)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
 	if _, err := w.Write(responseJSON); err != nil {
 		log.Println(err)
 	}


### PR DESCRIPTION
## Summary

To enable automated preflight checks from browsers, we need to handle requests with empty bodies. This PR addresses that issue and just returns an empty-bodied response with proper headers.