### PR TITLE
Re-fetch After Create

### DIFF
--- a/service/school_service.go
+++ b/service/school_service.go
@@ -62,7 +62,7 @@ func (s *SchoolService) CreateSchool(school *model.School) (*model.School, error
 	if err != nil {
 		return nil, err
 	}
-	return school, nil
+	return s.FindByID(school.ID)
 }
 
 func (s *SchoolService) List(first *int32, after *string) ([]*model.School, error) {

--- a/service/student_service.go
+++ b/service/student_service.go
@@ -57,7 +57,7 @@ func (s *StudentService) CreateStudent(student *model.Student) (*model.Student, 
 	if err != nil {
 		return nil, err
 	}
-	return student, nil
+	return s.FindByID(student.ID)
 }
 
 func (s *StudentService) List(first *int32, after *string) ([]*model.Student, error) {

--- a/service/survey_service.go
+++ b/service/survey_service.go
@@ -80,5 +80,8 @@ func (s *SurveyService) TransactionalCreateSurvey(survey *model.Survey) (*model.
 
 		return nil
 	})
-	return survey, err
+	if err != nil {
+		return nil, err
+	}
+	return s.FindByID(survey.ID)
 }

--- a/service/user_service.go
+++ b/service/user_service.go
@@ -62,7 +62,7 @@ func (u *UserService) CreateUser(user *model.User) (*model.User, error) {
 		return nil, err
 	}
 
-	return user, nil
+	return u.FindByEmail(user.Email)
 }
 
 func (u *UserService) List(first *int32, after *string) ([]*model.User, error) {


### PR DESCRIPTION
## Summary

Previously any `create` operation would return the input instead of the created record. This PR fixes that issue.