### PR TITLE
Fix Coverage Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![GitHub license](https://img.shields.io/github/license/kerti/idcra-api.svg)](https://github.com/kerti/idcra-api/blob/master/LICENSE)
 [![GolangCI](https://golangci.com/badges/github.com/kerti/idcra-api.svg)](https://golangci.com/r/github.com/kerti/idcra-api)
 [![Build Status](https://travis-ci.org/kerti/idcra-api.svg?branch=master)](https://travis-ci.org/kerti/idcra-api)
-[![Coverage Status](https://coveralls.io/repos/github/kerti/idcra-api/badge.svg?branch=travis-ci)](https://coveralls.io/github/kerti/idcra-api?branch=travis-ci)
+[![Coverage Status](https://coveralls.io/repos/github/kerti/idcra-api/badge.svg?branch=master)](https://coveralls.io/github/kerti/idcra-api?branch=master)
 
 # idcra-api
 


### PR DESCRIPTION
## Summary

Previously the badge pointed at the `travis-ci` branch. It now points to `master`.